### PR TITLE
Fix constructors.

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -30,7 +30,7 @@
  */
 Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire)
     : _cs(-1), _mosi(-1), _miso(-1), _sck(-1) {
-  *_wire = *theWire;
+  _wire = theWire;
 }
 
 /*!
@@ -42,7 +42,7 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire)
  */
 Adafruit_BMP280::Adafruit_BMP280(int8_t cspin, SPIClass *theSPI)
     : _cs(cspin), _mosi(-1), _miso(-1), _sck(-1) {
-  *_spi = *theSPI;
+  _spi = theSPI;
 }
 
 /*!


### PR DESCRIPTION
Actually assign the pointers instead of using copy constructors.

The current code leads to undefined behaviour, due to some random address(the inital value of the pointers) having some object copied into it.

I.e. with my ESP8266 the serial output is changed to garbage as soon as the Adafruit_BMP280 object is defined globally as is the case in the example
